### PR TITLE
Update numba to 0.56.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "numba" %}
-{% set version = "0.56.3" %}
-{% set sha256 = "8c8957219e0356cc82d366fcde13a797c329c0fc8ed4c13fdf748265922a28d5" %}
+{% set version = "0.56.4" %}
+{% set sha256 = "ab96b731fb9dee12b404b42b7c1fb82c119352648906a80526afa73658895b73" %}
 {% set numpy_min_ver = "1.18" %}  # [py<39 and not (aarch64 or s390x or arm64)]
 {% set numpy_min_ver = "1.19" %}  # [py<39 and (aarch64 or s390x or arm64)]
 {% set numpy_min_ver = "1.19" %}  # [py==39 and not arm64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,7 +60,7 @@ requirements:
     # xref: https://github.com/numba/numba/issues/7756
     # NumPy >=1.23 breaks with CUDA test: test_reinterpret_array_type
     # xref: https://github.com/numba/numba/issues/8529
-    - numpy >={{ numpy_min_ver }},!=1.22.0,!=1.22.1,!=1.22.2,<1.23
+    - numpy >={{ numpy_min_ver }},!=1.22.0,!=1.22.1,!=1.22.2,<1.24
     # needed for pkg_resources
     - setuptools
 


### PR DESCRIPTION
## Changes

- Updated `numpy` upper bound to `<1.24` in `run` section

## Links

- GitHub: https://github.com/numba/numba/tree/0.56.4
- Release History: https://github.com/numba/numba/releases
- `numba` recipe: https://github.com/numba/numba/blob/0.56.4/buildscripts/condarecipe.local/meta.yaml

## Notes

- This is a bugfix release to address issues with `numpy >=1.23` that were present in the last release.
- GPU tests with CUDA were performed outside of Prefect, and passed for `linux-64` and `win-64`.

- 👉 **Prefect is not capable of completing the `win-64` tests without timing out, so please ignore the failure** -- this platform will use a build performed on a dev instance. 