### PR TITLE
numba 0.60.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/llvmlite-feedstock/pr12/dc610d7

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,2 @@
-aggregate_branch: 3.12
+channels:
+  - https://staging.continuum.io/prefect/fs/llvmlite-feedstock/pr12/dc610d7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   patches:
     # This forces a benign DeprecationWarning in test_import.py to be ignored.
     - patches/ignore_deprecation_warning_in_import_test.patch  # [py>=310 and win]
-    # Build with numpy >=1.11 instead of 2.0.0rc1
+    # Build with numpy >=1.22.3 instead of 2.0.0rc1
     - patches/fix_numpy.patch
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,8 @@ requirements:
     - {{ compiler('cxx') }}
     # llvm is needed for the headers
     - llvm-openmp              # [osx]
-    - m2-patch  # [py>=310 and win]
+    - m2-patch  # [win]
+    - patch     # [unix]
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,27 +1,29 @@
 {% set name = "numba" %}
-{% set version = "0.59.1" %}
+{% set version = "0.60.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/numba-{{ version }}.tar.gz
-  sha256: 76f69132b96028d2774ed20415e8c528a34e3299a40581bae178f0994a2f370b
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 5df6158e5584eece5fc83294b949fd30b9f1125df7708862205217e068aabf16
   patches:
-    - patches/ignore_deprecation_warning_in_import_test.patch  # [py>=310 and win]
     # This forces a benign DeprecationWarning in test_import.py to be ignored.
+    - patches/ignore_deprecation_warning_in_import_test.patch  # [py>=310 and win]
+    # Build with numpy >=1.11 instead of 2.0.0rc1
+    - patches/fix_numpy.patch
 
 build:
   number: 0
-  entry_points:
-    - numba = numba.misc.numba_entry:main
+  skip: true  # [python_impl == 'pypy']
+  skip: true  # [py<39 or s390x]
   script:
     - export CC="${CC} -pthread"  # [linux]
     - export CXX="${CXX} -pthread"  # [linux]
     - {{ PYTHON }} -m pip install . --no-deps  --no-build-isolation --ignore-installed -vv
-  skip: true  # [python_impl == 'pypy']
-  skip: true  # [py<39 or py>312 or s390x]
+  entry_points:
+    - numba = numba.misc.numba_entry:main
   ignore_run_exports:
     - libllvm14 >=14.0.6,<14.1.0a0
 
@@ -37,14 +39,14 @@ requirements:
     - pip
     - setuptools
     - wheel
-    - llvmlite 0.42.0
+    - llvmlite 0.43.0
     - numpy 1.22.3 # [py<311]
     - numpy {{ numpy }} # [py>=311]
     - tbb-devel 2021.8.0
     - _openmp_mutex 5.1        # [linux]
   run:
     - python
-    - llvmlite >=0.42.0,<0.43.0a0
+    - llvmlite >=0.43.0,<0.44.0a0
     - {{ pin_compatible('numpy', upper_bound='1.27') }}
 
   run_constrained:
@@ -52,8 +54,9 @@ requirements:
     # avoid confusion from openblas bugs
     - libopenblas !=0.3.6      # [x86_64]
     - libopenblas >=0.3.18, !=0.3.20  # [arm64]
-    # CUDA 10.2 or later is required for CUDA support
-    - cudatoolkit >=10.2
+    # CUDA 11.2 or later is required for CUDA support
+    - cuda-version >=11.2
+    - cudatoolkit >=11.2
     # scipy 1.0 or later
     - scipy >=1.0
     # CUDA Python 11.6 or later
@@ -114,8 +117,8 @@ about:
   license_file: LICENSE
   summary: NumPy aware dynamic Python compiler using LLVM
   description: |
-    Numba is an Open Source NumPy-aware optimizing compiler for Python 
-    sponsored by Anaconda, Inc. It uses the remarkable LLVM compiler 
+    Numba is an Open Source NumPy-aware optimizing compiler for Python
+    sponsored by Anaconda, Inc. It uses the remarkable LLVM compiler
     infrastructure to compile Python syntax to machine code."
   dev_url: https://github.com/numba/numba
   doc_url: https://numba.readthedocs.io/

--- a/recipe/patches/fix_numpy.patch
+++ b/recipe/patches/fix_numpy.patch
@@ -1,0 +1,24 @@
+From 154a9df61ce05820a20c44484de9bed63462bec5 Mon Sep 17 00:00:00 2001
+From: Serhii Kupriienko
+Date: Wed, 3 Jul 2024 13:22:59 +0300
+Subject: Fix numpy
+
+---
+ setup.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/setup.py b/setup.py
+index 69a3f9590..54571c07e 100644
+--- a/setup.py
++++ b/setup.py
+@@ -21,7 +21,7 @@ except ImportError:
+ 
+ min_python_version = "3.9"
+ max_python_version = "3.13"  # exclusive
+-min_numpy_build_version = "2.0.0rc1"
++min_numpy_build_version = "1.22.3"
+ min_numpy_run_version = "1.22"
+ max_numpy_run_version = "2.1"
+ min_llvmlite_version = "0.43.0dev0"
+-- 
+2.44.0


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-5124](https://anaconda.atlassian.net/browse/PKG-5124) 
- [Upstream repository]()
- Requirements: https://github.com/numba/numba/blob/0.60.0/setup.py

### Explanation of changes:

- Update `llvmlite` pinning, https://github.com/AnacondaRecipes/llvmlite-feedstock/pull/12
- Add a patch to fix the `numpy` lower bound for building the package.

### Notes:

-

[PKG-5124]: https://anaconda.atlassian.net/browse/PKG-5124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ