### PR TITLE
numba 0.61.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/python-feedstock/pr182/32b35f1

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
+channels:
+  - https://staging.continuum.io/prefect/fs/python-feedstock/pr182/32b35f1

--- a/recipe/0002-fix-python-3.13.4.patch
+++ b/recipe/0002-fix-python-3.13.4.patch
@@ -1,0 +1,35 @@
+From 658d387562fb63459e83f3c1b8b31b51a368ccfe Mon Sep 17 00:00:00 2001
+From: Siu Kwan Lam <1929845+sklam@users.noreply.github.com>
+Date: Mon, 9 Jun 2025 15:41:24 -0500
+Subject: [PATCH 2/2] Fix list-comprehension for python 3.13.4
+
+---
+ numba/core/bytecode.py | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/numba/core/bytecode.py b/numba/core/bytecode.py
+index 3df9c06bd..c312c8fe8 100644
+--- a/numba/core/bytecode.py
++++ b/numba/core/bytecode.py
+@@ -2,6 +2,7 @@ from collections import namedtuple, OrderedDict
+ import dis
+ import inspect
+ import itertools
++import sys
+ 
+ from types import CodeType, ModuleType
+ 
+@@ -538,8 +539,12 @@ class ByteCodePy312(ByteCodePy311):
+                 # If we see a GET_ITER here, check if the next thing is a
+                 # FOR_ITER.
+                 if next_inst.opname == "GET_ITER":
+-                    # Add the inst to potentially be replaced to NOP
+-                    current_nop_fixes.add(next_inst)
++                    # In Python 3.13.4, this becomes the only GET_ITER,
++                    # so don't turn it into a NOP.
++                    # Python 3.13.5 reverted the change.
++                    if sys.version_info[:3] != (3, 13, 4):
++                        # Add the inst to potentially be replaced to NOP.
++                        current_nop_fixes.add(next_inst)
+                     # Loop up next instruction.
+                     next_inst = self.table[self.ordered_offsets[index + 3]]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,4 @@
+c_compiler_version:
+  - 17.0.6            # [osx]
+cxx_compiler_version:
+  - 17.0.6            # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "numba" %}
-{% set version = "0.61.0" %}
+{% set version = "0.61.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 888d2e89b8160899e19591467e8fdd4970e07606e1fbc248f239c89818d5f925
+  sha256: 8750ee147940a6637b80ecf7f95062185ad8726c8c28a2295b8ec1160a196f7d
   patches:
     - 0001-skip-pycc-and-overlaod_allocation-tests.patch
 
 build:
-  number: 1
+  number: 0
   skip: true  # [python_impl == 'pypy']
   skip: true  # [(py<310 or py>=314) or s390x]
   script:
@@ -36,14 +36,14 @@ requirements:
     - setuptools
     - wheel
     - llvmlite 0.44.0
-    - numpy 2.1.3
+    - numpy >=2.0.0rc1,<2.3
     - tbb-devel 2021.8.0
     - _openmp_mutex 5.1        # [linux]
   run:
     - python
-    - llvmlite >=0.44.0,<0.45.0a0
+    - llvmlite >=0.44.0dev0,<0.45
     # avoid 2.0.1 because of https://github.com/numpy/numpy/pull/27195
-    - numpy >=1.24,<2.2,!=2.0.1
+    - numpy >=1.24,<2.3,!=2.0.1
   run_constrained:
     - tbb >=2021.6,<2022
     # avoid confusion from openblas bugs

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha256: 8750ee147940a6637b80ecf7f95062185ad8726c8c28a2295b8ec1160a196f7d
   patches:
     - 0001-skip-pycc-and-overlaod_allocation-tests.patch
+    - 0002-fix-python-3.13.4.patch
 
 build:
   number: 0


### PR DESCRIPTION
## ☆ numba 0.61.2 ☆
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-8081) 
[Upstream](https://github.com/numba/numba)

### Changes
* Updated numba from 0.61.0 to 0.61.2
* Added patch to fix Python 3.13.4 compatibility issue with list comprehensions
* Updated numpy constraints from fixed version 2.1.3 to range >=2.0.0rc1,<2.3 in host requirements
* Updated numpy constraints in run requirements to >=1.24,<2.3,!=2.0.1
* Updated llvmlite constraint to >=0.44.0dev0,<0.45
* Reset build number to 0
* Removed abs.yaml file