### PR TITLE
numba 0.65.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "numba" %}
-{% set version = "0.65.0" %}
+{% set version = "0.65.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: edad0d9f6682e93624c00125a471ae4df186175d71fd604c983c377cdc03e68b
+  sha256: 19357146c32fe9ed25059ab915e8465fb13951cf6b0aace3826b76886373ab23
 
 build:
   number: 0


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-13824](https://anaconda.atlassian.net/browse/PKG-13824)
- [Upstream repository](https://github.com/numba/numba/tree/0.65.1)
- [Upstream changelog/diff](https://numba.readthedocs.io/en/stable/release/0.65.1-notes.html)

### Explanation of changes:

- new build number and sha256


[PKG-13824]: https://anaconda.atlassian.net/browse/PKG-13824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ